### PR TITLE
Fix `jupyenv` typo in `src/flakeOutputs.nix`

### DIFF
--- a/src/flakeOutputs.nix
+++ b/src/flakeOutputs.nix
@@ -40,7 +40,7 @@ in
     }).exports.default;
 
   units = {
-    inherit (outputs) configs std jupenv;
+    inherit (outputs) configs std jupyenv;
 
     nixos = {
       inherit (outputs)


### PR DESCRIPTION
inheriting `outputs.jupenv` which doesn't exist.